### PR TITLE
Serverless support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM public.ecr.aws/bitnami/python:3.6
+COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory
 WORKDIR /
@@ -15,4 +17,4 @@ COPY . .
 EXPOSE 8000
 
 # Run the script
-ENTRYPOINT ["sh", "/django.sh"]
+ENTRYPOINT ["/opt/tinystacks-secret-env-vars-wrapper", "sh", "/django.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/bitnami/python:3.6
-COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/tinystacks/secret-env-vars-wrapper:latest-x86 /opt /opt
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ If you have Docker installed, you can build and try out the sample application l
 docker build -t tinystacks/django-crud-app:latest .
 ```
 
-Once built, run the Docker command locally, mapping port 8080 on your host machine to port 80 on the container: 
+Once built, run the Docker command locally, mapping port 8080 on your host machine to port 8000 on the container: 
 
 ```
-docker run -p 8080:80 -d tinystacks/django-crud-app:latest
+docker run -p 8080:8000 -d tinystacks/django-crud-app:latest
 ```
 
 To test that the server is running, test its `/ping` endpoint by navigating to `http://127.0.0.1:8080/ping` from a Web browser. You should see the same page you saw earlier when running Django locally. 
@@ -237,10 +237,10 @@ If you already have an existing Django application, you can use the core files i
 
 If your project is already Dockerized (i.e., it has its own Dockerfile), then simply copy over the `build.yml` and `release.yml` files into the root of your existing project. 
 
-If your project is not Dockerized, you will also need to copy over the Dockerfile included in this sample. If your application uses a different port than port 80, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
+If your project is not Dockerized, you will also need to copy over the Dockerfile included in this sample. If your application uses a different port than port 8000, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
 
 ```Dockerfile
-EXPOSE 80
+EXPOSE 8000
 ```
 
 ## Preparing for Production Deployment

--- a/django.sh
+++ b/django.sh
@@ -3,4 +3,4 @@ echo "Starting Migrations..."
 python manage.py migrate
 echo ============================================
 echo "Starting Server..."
-python manage.py runserver 0.0.0.0:80
+python manage.py runserver 0.0.0.0:8000

--- a/release.yml
+++ b/release.yml
@@ -10,4 +10,19 @@ phases:
     on-failure: CONTINUE
     commands:
       - region="${STAGE_REGION:-$AWS_REGION}" 
-      - if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ]; then echo 'Service is not ready yet. Repository tagged correctly, exiting now'; else  aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment; fi
+      - |
+        if [ ! -z "$LAMBDA_FUNCTION_NAME" -a  "$LAMBDA_FUNCTION_NAME" != "placeholder" ];
+          then
+            aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --image-uri "$ECR_IMAGE_URL:$STAGE_NAME" --region $region
+            imageSha=$(docker images --no-trunc --quiet $ECR_IMAGE_URL:$PREVIOUS_STAGE_NAME);
+            aws lambda tag-resource --resource "$LAMBDA_FUNCTION_ARN" --tags "IMAGE_SHA=$imageSha"
+          else
+            echo 'Not a serverless stage'
+            if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ];
+              then
+                echo 'Service is not ready yet. Repository tagged correctly, exiting now';
+              else
+                aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment;
+            fi
+        fi
+        


### PR DESCRIPTION
This PR includes the following changes in order to support serverless hosting on lambda:
1. Include two lambda extensions in Dockerfile
    - One for adapting to Lambda events
    - One for Secrets Manager support
2. Update release.yml
3. Change default port
    - port 80 cannot be used on Lambda (no privileged port can be used i.e. below 1024)